### PR TITLE
Extend output formats for dirtree tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install clean lint test build develop dev-install setup
+.PHONY: install clean lint test build develop dev-install dev-setup
 
 # Development installation
 develop:
@@ -9,7 +9,7 @@ dev-install:
 	pip install -r requirements-dev.txt
 
 # Development setup (combine develop and dev-install)
-setup: develop dev-install
+dev-setup: develop dev-install
 
 # Production installation
 install:

--- a/src/cli.py
+++ b/src/cli.py
@@ -6,9 +6,9 @@ from pathlib import Path
 from tqdm import tqdm
 
 from src.config import load_config
-from src.formatters import (ConsoleFormatter, JSONFormatter,  # Update import
-                            MarkdownFormatter)
-from src.tree_generator import DirectoryTree  # Update import
+from src.formatters import (ConsoleFormatter, JSONFormatter, MarkdownFormatter, 
+                            XMLFormatter, HTMLFormatter, CSVFormatter, PlainTextFormatter)
+from src.tree_generator import DirectoryTree
 
 
 def setup_logging(verbose: bool, log_file: str = "dirtree.log"):
@@ -55,7 +55,7 @@ def main():
     parser.add_argument(
         "-f",
         "--format",
-        choices=["console", "markdown", "json"],
+        choices=["console", "markdown", "json", "xml", "html", "csv", "plaintext"],
         help="Output format (default: console)",
     )
     parser.add_argument("-o", "--output", help="Output file path")
@@ -105,6 +105,10 @@ def main():
             "console": ConsoleFormatter,
             "markdown": MarkdownFormatter,
             "json": JSONFormatter,
+            "xml": XMLFormatter,
+            "html": HTMLFormatter,
+            "csv": CSVFormatter,
+            "plaintext": PlainTextFormatter,
         }[config["format"]]()
 
         logger.info(f"Starting tree generation for directory: {args.directory}")

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,4 +1,4 @@
-from src.formatters import ConsoleFormatter, MarkdownFormatter, JSONFormatter
+from src.formatters import ConsoleFormatter, MarkdownFormatter, JSONFormatter, XMLFormatter, HTMLFormatter, CSVFormatter, PlainTextFormatter
 from src.tree_generator import DirectoryTree
 
 def test_console_formatter():
@@ -31,3 +31,32 @@ def test_json_formatter():
     result = formatter.get_output()
     assert '"dir1": {' in result
     assert '"file1.txt": null' in result
+
+def test_xml_formatter():
+    formatter = XMLFormatter()
+    formatter.add_entry(["dir1"], True)
+    formatter.add_entry(["dir1", "file1.txt"], False)
+    result = formatter.get_output()
+    assert '<directory name="dir1">' in result
+    assert '<file name="file1.txt"/>' in result
+
+def test_html_formatter():
+    formatter = HTMLFormatter()
+    result = formatter.format_line("    ", "test.txt", False)
+    assert "&nbsp;&nbsp;&nbsp;&nbsp;├── test.txt<br>" in result
+
+def test_csv_formatter():
+    formatter = CSVFormatter()
+    formatter.add_entry(["dir1"], True)
+    formatter.add_entry(["dir1", "file1.txt"], False)
+    result = formatter.get_output()
+    assert "dir1" in result
+    assert "file1.txt" in result
+
+def test_plaintext_formatter():
+    formatter = PlainTextFormatter()
+    result = formatter.format_line("    ", "test.txt", False)
+    assert result == "    ├── test.txt"
+    
+    result = formatter.format_line("    ", "test.txt", True)
+    assert result == "    └── test.txt"


### PR DESCRIPTION
Add support for multiple output formats and update tests accordingly.

* **src/formatters.py**
  - Add `XMLFormatter` class to support XML output format.
  - Add `HTMLFormatter` class to support HTML output format.
  - Add `CSVFormatter` class to support CSV output format.
  - Add `PlainTextFormatter` class to support plain text output format.

* **src/cli.py**
  - Update `formatter` dictionary to include new formatters.
  - Add new format options to `argparse` choices.

* **tests/test_formatters.py**
  - Add tests for `XMLFormatter` class.
  - Add tests for `HTMLFormatter` class.
  - Add tests for `CSVFormatter` class.
  - Add tests for `PlainTextFormatter` class.

* **Makefile**
  - Update `setup` target to `dev-setup`.
  - Add `dev-setup` to `.PHONY` list.

